### PR TITLE
4KDST-10: Component Library / Tokens / Border Radius

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "bracketSpacing": true,
+  "bracketSameLine": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "sass": "^1.81.0",
         "style-dictionary": "^4.2.0",
         "token-transformer": "^0.0.33",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "typescript-plugin-css-modules": "^5.1.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",
@@ -2183,6 +2184,22 @@
         "undici-types": "~6.19.8"
       }
     },
+    "node_modules/@types/postcss-modules-local-by-default": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.2.tgz",
+      "integrity": "sha512-CtYCcD+L+trB3reJPny+bKWKMzPfxEyQpKIwit7kErnOexf5/faaGpkFy4I5AwbV4hp1sk7/aTg0tt0B67VkLQ==",
+      "dependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/@types/postcss-modules-scope": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/postcss-modules-scope/-/postcss-modules-scope-3.0.4.tgz",
+      "integrity": "sha512-//ygSisVq9kVI0sqx3UPLzWIMCmtSVrzdljtuaAEJtGoGnpjBikZ2sXO5MpH9SnWX9HRfXxHifDAXcQjupWnIQ==",
+      "dependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
@@ -2785,6 +2802,17 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/copy-anything": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
+      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "dependencies": {
+        "is-what": "^3.14.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2805,6 +2833,17 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2816,7 +2855,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2928,6 +2966,17 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2945,6 +2994,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "optional": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -3348,6 +3409,29 @@
         "node": ">=10.18"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3367,6 +3451,18 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/immutable": {
       "version": "5.0.3",
@@ -3546,6 +3642,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA=="
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -3668,6 +3769,39 @@
         "graceful-fs": "^4.1.11"
       }
     },
+    "node_modules/less": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.1.tgz",
+      "integrity": "sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==",
+      "dependencies": {
+        "copy-anything": "^2.0.1",
+        "parse-node-version": "^1.0.1",
+        "tslib": "^2.3.0"
+      },
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "needle": "^3.1.0",
+        "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3688,6 +3822,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3731,6 +3870,28 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/map-or-similar": {
@@ -3790,6 +3951,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3830,26 +4003,39 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/needle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
       }
     },
     "node_modules/node-addon-api": {
@@ -3988,6 +4174,14 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/patch-package": {
       "version": "8.0.0",
@@ -4144,8 +4338,7 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "4.0.2",
@@ -4157,6 +4350,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/polished": {
@@ -4183,7 +4385,6 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4198,7 +4399,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -4207,6 +4407,100 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dependencies": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.1.0.tgz",
+      "integrity": "sha512-rm0bdSv4jC3BDma3s9H19ZddW0aHX6EoqwDYU2IfZhRN+53QrufTRo2IdkAbRqLx4R2IYbZnbjKKxg4VN5oU9Q==",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prettier": {
       "version": "3.4.1",
@@ -4257,6 +4551,12 @@
       "engines": {
         "node": ">= 0.6.0"
       }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "optional": true
     },
     "node_modules/punycode": {
       "version": "1.4.1",
@@ -4422,6 +4722,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw=="
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -4510,6 +4815,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "optional": true
+    },
     "node_modules/sass": {
       "version": "1.81.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
@@ -4528,6 +4839,12 @@
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "optional": true
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -4627,7 +4944,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4776,7 +5093,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4836,6 +5152,45 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/stylus": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.62.0.tgz",
+      "integrity": "sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==",
+      "dependencies": {
+        "@adobe/css-tools": "~4.3.1",
+        "debug": "^4.3.2",
+        "glob": "^7.1.6",
+        "sax": "~1.3.0",
+        "source-map": "^0.7.3"
+      },
+      "bin": {
+        "stylus": "bin/stylus"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://opencollective.com/stylus"
+      }
+    },
+    "node_modules/stylus/node_modules/@adobe/css-tools": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="
+    },
+    "node_modules/stylus/node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
+    "node_modules/stylus/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/supports-color": {
@@ -4967,7 +5322,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "dev": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -5010,6 +5364,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-plugin-css-modules": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.1.0.tgz",
+      "integrity": "sha512-6h+sLBa4l+XYSTn/31vZHd/1c3SvAbLpobY6FxDiUOHJQG1eD9Gh3eCs12+Eqc+TCOAdxcO+zAPvUq0jBfdciw==",
+      "dependencies": {
+        "@types/postcss-modules-local-by-default": "^4.0.2",
+        "@types/postcss-modules-scope": "^3.0.4",
+        "dotenv": "^16.4.2",
+        "icss-utils": "^5.1.0",
+        "less": "^4.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^8.4.35",
+        "postcss-load-config": "^3.1.4",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.4",
+        "postcss-modules-scope": "^3.1.1",
+        "reserved-words": "^0.1.2",
+        "sass": "^1.70.0",
+        "source-map-js": "^1.0.2",
+        "stylus": "^0.62.0",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/undici-types": {
@@ -5093,6 +5473,11 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "sass": "^1.81.0",
     "style-dictionary": "^4.2.0",
     "token-transformer": "^0.0.33",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "typescript-plugin-css-modules": "^5.1.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/src/foundation/breakpoints/_breakpoints.scss
+++ b/src/foundation/breakpoints/_breakpoints.scss
@@ -1,0 +1,67 @@
+/**
+ * Breakpoint Configuration
+ * @see https://github.com/Team-Sass/breakpoint/wiki
+ *
+ */
+
+/////////////////////
+// Global Breakpoints
+@use 'sass:map';
+@use 'sass:meta';
+@use '../utility/rem-calc' as *;
+
+$xsmall: rem-calc(610);
+$small: rem-calc(767);
+$medium: rem-calc(1040);
+$large: rem-calc(1280);
+$xlarge: rem-calc(1640);
+$xxlarge: rem-calc(1920);
+$xxxlarge: rem-calc(2560);
+$xsmall-down: rem-calc(#{$small - 0.05});
+$small-down: rem-calc(#{$medium - 0.05});
+$medium-down: rem-calc(#{$large - 0.05});
+$breakpoints: (
+  'xsmall': (
+    min-width: #{$xsmall},
+  ),
+  'xsmall-down': (
+    max-width: #{$xsmall-down},
+  ),
+  'small': (
+    min-width: #{$small},
+  ),
+  'small-down': (
+    max-width: #{$small-down},
+  ),
+  'medium': (
+    min-width: #{$medium},
+  ),
+  'medium-down': (
+    max-width: #{$medium-down},
+  ),
+  'large': (
+    min-width: #{$large},
+  ),
+  'xlarge': (
+    min-width: #{$xlarge},
+  ),
+  'xxlarge': (
+    min-width: #{$xxlarge},
+  ),
+);
+
+/// Mixin to manage responsive breakpoints
+/// @param {String} $breakpoint - Breakpoint name
+/// @require $breakpoints map
+@mixin breakpoint($breakpoint) {
+  // If the key exists in the map
+  @if map.has-key($breakpoints, $breakpoint) {
+    @media #{meta.inspect(map.get($breakpoints, $breakpoint))} {
+      @content;
+    }
+  } @else {
+    /* stylelint-disable-next-line at-rule-no-unknown */
+
+    @error "Unfortunately, no value could be retrieved from `#{$breakpoint}`. Available breakpoints are: #{map-keys($breakpoints)}.";
+  }
+}

--- a/src/foundation/motion/_motion.scss
+++ b/src/foundation/motion/_motion.scss
@@ -1,0 +1,74 @@
+/* Mixin - Transition */
+$transition-duration-base: 0.3s;
+$transition-timing-function-base: ease-in-out;
+
+@mixin transition(
+  $transition-property: all,
+  $transition-duration: $transition-duration-base,
+  $transition-timing-function: $transition-timing-function-base
+) {
+  & {
+    transition: $transition-property $transition-duration
+      $transition-timing-function;
+  }
+}
+
+// This animation is to remove hidden items from screen readers and
+// keyboard navigation, while maintaining the slow "close" effect.
+@mixin animate-show($speed: $transition-duration-base, $delay: 0ms) {
+  & {
+    animation: #{$speed} show;
+    animation-fill-mode: forwards;
+    animation-delay: $delay;
+  }
+
+  @keyframes show {
+    // Start visible at 0% to avoid an occasional "flash" when closing.
+    0% {
+      visibility: hidden;
+      opacity: 0;
+    }
+
+    2% {
+      visibility: visible;
+    }
+
+    100% {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+}
+
+@mixin animate-hidden(
+  $speed: $transition-duration-base,
+  $hide-position: 'false'
+) {
+  @if $hide-position == 'true' {
+    animation: hidden, position-change;
+  } @else {
+    animation: hidden;
+  }
+
+  & {
+    animation-duration: #{$speed};
+    animation-fill-mode: forwards;
+  }
+
+  @keyframes hidden {
+    // Start visible at 0% to avoid an occasional "flash" when closing.
+    0% {
+      visibility: visible;
+      opacity: 1;
+    }
+
+    99% {
+      visibility: visible;
+    }
+
+    100% {
+      visibility: hidden;
+      opacity: 0;
+    }
+  }
+}

--- a/src/foundation/spacing/_spacing.scss
+++ b/src/foundation/spacing/_spacing.scss
@@ -1,0 +1,47 @@
+@use 'sass:math';
+@use '../breakpoints/breakpoints' as *;
+
+@mixin section-padding-top($multiplier: 1) {
+  & {
+    padding-top: var(--spacing-xl);
+  }
+
+  @include breakpoint('large') {
+    padding-top: calc(var(--spacing-xl) * #{$multiplier});
+  }
+}
+
+@mixin section-padding-bottom($multiplier: 1) {
+  & {
+    padding-bottom: var(--spacing-xl);
+  }
+
+  @include breakpoint('large') {
+    padding-bottom: calc(var(--spacing-xl) * #{$multiplier});
+  }
+}
+
+@mixin section-padding($multiplier: 1) {
+  @include section-padding-top($multiplier);
+  @include section-padding-bottom($multiplier);
+}
+
+@mixin margin-gap-top($multiplier: 1) {
+  & {
+    margin-top: calc(var(--spacing-xl) * #{$multiplier});
+  }
+
+  @include breakpoint('large') {
+    margin-top: calc(var(--spacing-2xl) * #{$multiplier});
+  }
+}
+
+@mixin margin-gap-bottom($multiplier: 1) {
+  &:not(:last-child) {
+    margin-bottom: calc(var(--spacing-xl) * #{$multiplier});
+
+    @include breakpoint('large') {
+      margin-bottom: calc(var(--spacing-2xl) * #{$multiplier});
+    }
+  }
+}

--- a/src/foundation/typography/_fonts.scss
+++ b/src/foundation/typography/_fonts.scss
@@ -1,0 +1,9 @@
+// $font-url: '../../assets/fonts';
+
+// @font-face {
+//   font-family: [font-family];
+//   src: url('#{$font-url}/[font-filename]') format('truetype');
+//   font-weight: 500;
+//   font-style: normal;
+//   font-display: swap;
+// }

--- a/src/foundation/typography/_typography.scss
+++ b/src/foundation/typography/_typography.scss
@@ -1,0 +1,96 @@
+// Heading mixins
+@mixin h1 {
+  font-size: var(--font-size-h1);
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-none);
+}
+
+@mixin h2 {
+  font-size: var(--font-size-h2);
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-none);
+}
+
+@mixin h3 {
+  font-size: var(--font-size-h3);
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  letter-spacing: var(--letter-spacing-0);
+  line-height: var(--line-height-none);
+}
+
+@mixin h4 {
+  font-size: var(--font-size-h4);
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  letter-spacing: var(--letter-spacing-0);
+  line-height: var(--line-height-none);
+}
+
+@mixin h5 {
+  font-size: var(--font-size-h5);
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  letter-spacing: var(--letter-spacing-0);
+  line-height: var(--line-height-none);
+}
+
+// Body mixins
+@mixin body-xl {
+  font-size: clamp(
+    #{$font-size-24},
+    #{$font-size-24} + 0.2778vw,
+    #{$font-size-28}
+  );
+  line-height: var(--line-height-loose);
+  font-family: var(--font-family-secondary);
+  font-weight: 400;
+}
+
+@mixin body-l {
+  font-size: clamp(
+    #{$font-size-20},
+    #{$font-size-20} + 0.2778vw,
+    #{$font-size-24}
+  );
+  line-height: var(--line-height-loose);
+  font-family: var(--font-family-secondary);
+  font-weight: 400;
+}
+
+@mixin body-default {
+  font-size: clamp(
+    #{$font-size-15},
+    #{$font-size-15} + 0.2778vw,
+    #{$font-size-16}
+  );
+  line-height: var(--line-height-loose);
+  font-family: var(--font-family-secondary);
+  font-weight: 400;
+}
+
+@mixin body-s {
+  font-size: clamp(
+    #{$font-size-13},
+    #{$font-size-13} + 0.2778vw,
+    #{$font-size-14}
+  );
+  line-height: var(--line-height-loose);
+  font-family: var(--font-family-secondary);
+  font-weight: 400;
+}
+
+@mixin body-xs {
+  font-size: clamp(
+    #{$font-size-12},
+    #{$font-size-12} + 0.2778vw,
+    #{$font-size-13}
+  );
+  line-height: var(--line-height-loose);
+  font-family: var(--font-family-secondary);
+  font-weight: 400;
+}

--- a/src/foundation/utility/_normalize.scss
+++ b/src/foundation/utility/_normalize.scss
@@ -1,0 +1,23 @@
+// Libraries.
+@use '../../../node_modules/normalize.css/normalize.css';
+
+/* Box sizing rules */
+html {
+  box-sizing: border-box;
+}
+
+/* Set core body defaults */
+body {
+  height: 100vh;
+  overflow: hidden auto;
+  scroll-snap-type: y mandatory;
+  scroll-behavior: smooth;
+  max-width: 100vw;
+  margin: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}

--- a/src/foundation/utility/_rem-calc.scss
+++ b/src/foundation/utility/_rem-calc.scss
@@ -1,0 +1,83 @@
+@use 'sass:list';
+@use 'sass:math';
+@use 'sass:meta';
+
+$base-font-size: 100%;
+
+/* stylelint-disable */
+/// Removes the unit (e.g. px, em, rem) from a value, returning the number only.
+///
+/// @param {Number} $num - Number to strip unit from.
+///
+/// @returns {Number} The same number, sans unit.
+@function strip-unit($num) {
+  @return math.div($num, ($num * 0 + 1));
+}
+
+/// Converts one or more pixel values into matching rem values.
+///
+/// @param {Number|List} $values - One or more values to convert. Be sure to separate them with spaces and not commas. If you need to convert a comma-separated list, wrap the list in parentheses.
+/// @param {Number} $base [null] - The base value to use when calculating the `rem`. If you're using Foundation out of the box, this is 16px. If this parameter is `null`, the function will reference the `$global-font-size` variable as the base.
+///
+/// @returns {List} A list of converted values.
+@function rem-calc($values, $base: null) {
+  $rem-values: ();
+  $count: list.length($values);
+
+  // If no base is defined, defer to the global font size
+  @if $base == null {
+    $base: $base-font-size;
+  }
+
+  // If the base font size is a %, then multiply it by 16px
+  // This is because 100% font size = 16px in most all browsers
+  @if math.unit($base) == '%' {
+    $base: (math.div($base, 100%)) * 16px;
+  }
+
+  // Using rem as base allows correct scaling
+  @if math.unit($base) == 'rem' {
+    $base: strip-unit($base) * 16px;
+  }
+
+  @if $count == 1 {
+    @return -zf-to-rem($values, $base);
+  }
+
+  @for $i from 1 through $count {
+    $rem-values: append($rem-values, -zf-to-rem(nth($values, $i), $base));
+  }
+
+  @return $rem-values;
+}
+
+/// Converts a pixel value to matching rem value. *Any* value passed, regardless of unit, is assumed to be a pixel value. By default, the base pixel value used to calculate the rem value is taken from the `$global-font-size` variable.
+/// @access private
+///
+/// @param {Number} $value - Pixel value to convert.
+/// @param {Number} $base [null] - Base for pixel conversion.
+///
+/// @returns {Number} A number in rems, calculated based on the given value and the base pixel value. rem values are passed through as is.
+@function -zf-to-rem($value, $base: null) {
+  // Check if the value is a number
+  @if meta.type-of($value) != 'number' {
+    @return $value;
+  }
+
+  // Transform em into rem if someone hands over 'em's
+  @if math.unit($value) == 'em' {
+    $value: strip-unit($value) * 1rem;
+  }
+
+  // Calculate rem if units for $value is not rem or em
+  @if math.unit($value) != 'rem' {
+    $value: math.div(strip-unit($value), strip-unit($base)) * 1rem;
+  }
+
+  // Turn 0rem into 0
+  @if $value == '0rem' {
+    $value: 0;
+  }
+
+  @return $value;
+}

--- a/src/foundation/utility/_utility.scss
+++ b/src/foundation/utility/_utility.scss
@@ -1,0 +1,62 @@
+@mixin visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
+}
+
+.visually-hidden,
+.sr-only {
+  @include visually-hidden;
+}
+
+// These are abstracted from the general use `focus` mixin below to support
+// use-cases like `focus-within` that apply to an "outer" element when something
+// "inside" has focus. e.g. The utility nav search box.
+@mixin focus-styles {
+  outline: var(--spacing-xs) dotted var(--color-emulsify-blue-900) !important;
+  outline-offset: var(--spacing-xs);
+}
+
+@mixin focus {
+  &:focus-visible {
+    @include focus-styles;
+  }
+
+  // Remove browser focus indicator from browsers that support `:focus-visible`
+  // This allows older browsers (e.g. Safari) to show default styles, while
+  // modern browsers use our focus designs.
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+}
+
+@mixin list-reset {
+  list-style: none;
+  margin: 0;
+  padding-inline: 0;
+}
+
+@mixin clearfix {
+  &::after {
+    content: ' ';
+    display: block;
+    clear: both;
+    margin: 0;
+  }
+}
+
+* {
+  @include focus;
+}
+
+body {
+  color: var(--colors-text-body);
+}
+
+body[data-body-frozen] {
+  overflow: hidden;
+  max-height: 100vh;
+}

--- a/src/foundation/utility/cl-base.module.scss
+++ b/src/foundation/utility/cl-base.module.scss
@@ -1,0 +1,153 @@
+// Base styles to apply to all story instances.
+@mixin sb-list-reset() {
+  padding: 0;
+  margin: 0;
+
+  li {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+.sb-show-main {
+  background: var(--colors-sb-background);
+  height: 100vh;
+
+  // color: var(--colors-sb-text-body);
+  font-family: var(--font-family-body), serif !important;
+}
+
+.sb-title {
+  color: var(--colors-sb-text-heading);
+  text-transform: uppercase;
+  font-size: var(--font-size-hero);
+  margin: 0 0 var(--spacing-2xl);
+  position: relative;
+  font-family: var(--font-family-body), serif !important;
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 0;
+    bottom: calc(-3 * var(--spacing-lg));
+    border-bottom: 10px solid var(--colors-sb-text-heading);
+    width: 100px;
+  }
+}
+
+.sb-subtitle {
+  font-family: var(--font-family-body), serif !important;
+  font-size: var(--font-size-h3);
+  opacity: var(--opacity-80);
+  margin: var(--spacing-2xl) 0 var(--spacing-md);
+}
+
+#root > div {
+  padding: var(--spacing-xl);
+}
+
+.sb-list {
+  @include sb-list-reset;
+
+  &__item {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    gap: var(--spacing-xl);
+    line-height: normal;
+    padding-block: var(--spacing-xl) !important;
+    padding-left: var(--spacing-md) !important;
+    border-bottom: 1px solid rgb(0 0 0 / 20%);
+  }
+
+  &__label {
+    min-width: 100px;
+  }
+
+  &__value {
+    min-width: 100px;
+  }
+
+  &__custom-property {
+    min-width: 275px;
+  }
+
+  &__visualization {
+    display: block;
+    width: 50px;
+    height: 50px;
+    border-radius: var(--radius-sm);
+    box-shadow: 0 3px 6px rgb(0 0 0 / 25%);
+  }
+}
+
+.sb-custom-property-name {
+  white-space: nowrap;
+  background-color: rgb(0 0 0 / 10%);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+}
+
+.sb-spacing-wrapper {
+  display: flex;
+  flex-flow: row nowrap;
+  background-color: #d606c1;
+}
+
+.sb-cover {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: bottom right;
+  padding: var(--spacing-2xl) !important;
+  display: flex;
+  justify-content: flex-end;
+  flex-flow: column nowrap;
+
+  &__logo {
+    max-width: 300px;
+    display: block;
+  }
+
+  &__title {
+    color: var(--color-white);
+    font-family: var(--font-family-body), serif !important;
+    font-size: var(--font-size-colossus);
+    line-height: var(--line-height-none);
+    margin: 0;
+  }
+}
+
+.sb_lozenge {
+  background: var(--color-primary-light);
+  color: var(--color-white);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-none);
+  display: block;
+  border-radius: var(--radius-lg);
+  width: max-content;
+  padding: var(--spacing-sm) var(--spacing-lg);
+}
+
+.cl-spaced-row {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 1rem;
+}
+
+.cl-intro {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  gap: 2rem;
+}
+
+.cl-container {
+  padding: 1rem 2rem;
+}
+
+[data-component-theme*='inverse'] {
+  background-color: var(--colors-sb-text-body);
+}

--- a/src/tokens/border-radius/border-radius-tokens.stories.tsx
+++ b/src/tokens/border-radius/border-radius-tokens.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import tokens from '../transformed.tokens.json';
+import BorderRadiusTokens from './border-radius-tokens';
+
+const meta = {
+  title: 'Tokens/Border Radius',
+  component: BorderRadiusTokens,
+} satisfies Meta<typeof BorderRadiusTokens>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BorderRadius: Story = {
+  args: {
+    borderRadius: Object.keys(tokens.radius).map((name) => {
+      return {
+        name,
+        value: tokens.radius[name as keyof typeof tokens.radius].value,
+      };
+    }),
+  },
+};

--- a/src/tokens/border-radius/border-radius-tokens.tsx
+++ b/src/tokens/border-radius/border-radius-tokens.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+// Utility classes for token display components.
+import clBase from '../../foundation/utility/cl-base.module.scss';
+
+type BorderRadiusTokensProps = {
+  borderRadius: {
+    name: string;
+    value: number;
+  }[];
+};
+
+export default function BorderRadiusTokens({
+  borderRadius,
+}: BorderRadiusTokensProps) {
+  return (
+    <div>
+      <h1 className={clBase['sb-title']}>Border Radius Tokens</h1>
+      <ul className={clBase['sb-list']}>
+        {borderRadius.map((item) => (
+          <li className={clBase['sb-list__item']} key={item.name}>
+            <span className={clBase['sb-list__label']}>{item.name}</span>
+            <span className={clBase['sb-list__value']}>{item.value}px</span>
+            <span className={clBase['sb-list__custom-property']}>
+              <code className={clBase['sb-custom-property-name']}>
+                var(--radius-{item.name})
+              </code>
+            </span>
+            <span
+              className={clBase['sb-list__visualization']}
+              style={{
+                borderRadius: `var(--radius-${item.name})`,
+                width: '75px',
+                height: '75px',
+                background: 'var(--colors-sb-visualization)',
+              }}></span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "_version": "2.0.0",
+
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "typescript-plugin-css-modules" }]
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Implements [4KDST-10: Component Library / Tokens / Border Radius](https://app.clickup.com/t/36718269/4KDST-10)

## How to review this pull request
- [x] Execute `npm run storybook`
- [x] Visit http://localhost:6006/?path=/story/tokens-border-radius--border-radius
- [x] Confirm that you see the list of border radius tokens, with their name, value, CSS variable and a demo element

## Notes

- Added all the `src/foundation` scss files from UI Kit. We'll probably remove or modify some in the future, but for now is better to have them available in the repo.
- Installed `typescript-plugin-css-modules`, a Typescript plugin that adds support for CSS modules in typescript.
- Renamed `src/foundation/utility/cl-base.scss` to `src/foundation/utility/cl-base.module.scss`, to allow its use as a SCSS module.
- BEM class names are not ideal for CSS modules, because the dashes and underscores prevent from using them as a key using the `.` (dot) notation. Had to use `['classname']` notation instead, which is less DX friendly. Didn't want to change anything for now, but we can consider change the naming conventions in the future.
